### PR TITLE
Update hide-my-email.md

### DIFF
--- a/docs/adguard-vpn-for-ios/solving-problems/hide-my-email.md
+++ b/docs/adguard-vpn-for-ios/solving-problems/hide-my-email.md
@@ -13,7 +13,7 @@ The feature is only available for iOS 15 and higher and requires an iCloud+ subs
 
 To use this feature, go to *Settings* → [Your Apple ID name] → *iCloud* → *Hide My Email*, tap *+ Create new address* and follow the on-screen instructions.
 
-You can generate a unique and random email address that forwards incoming messages to your actual address. It might look like this: chimney.floture_0s@privaterelay.appleid.com. There is no upper limit to the number of email addresses you can create. You can categorize them with labels and use each one for different purposes: signing up, receiving newsletters, etc. Apple ensures that the content of messages handled through the *Hide My Email* service is not inspected beyond standard spam filtering.
+You can generate a unique and random email address that forwards incoming messages to your actual address. It might look like this: chimney.floture_0s@icloud.com. There is no upper limit to the number of email addresses you can create. You can categorize them with labels and use each one for different purposes: signing up, receiving newsletters, etc. Apple ensures that the content of messages handled through the *Hide My Email* service is not inspected beyond standard spam filtering.
 
 The *Hide My Email* feature is also available in Apple’s Mail app. To send an email without disclosing your real email address, simply select *Hide My Email* in the *From* field when composing your message.
 


### PR DESCRIPTION
This update clarifies the distinction between addresses generated by Hide My Email and those generated by Sign in with Apple.
 - Replaced privaterelay.appleid.com with icloud.com to accurately reflect the domain used for Hide My Email addresses.