### PR TITLE
Add code to enable autocomplete so users can copy it

### DIFF
--- a/docs/adguard-vpn-for-linux/autocomplete.md
+++ b/docs/adguard-vpn-for-linux/autocomplete.md
@@ -9,6 +9,12 @@ To enable it, see the bash-completion hint that is shown after installing or upd
 
 ![bash-completion hint](https://cdn.adguard-vpn.com/blog/new/6x3djbash-completion-hint.png)
 
+If you didn't enable completions at install and want to do so later, edit your shell configuration (_typically a file like `~/.bashrc`, `~/.zshrc`, etc. which should already exist in your home directory_) and add the following line. You will need to update the path if you chose a different output directory during installation.
+
+```sh
+[ -s "/opt/adguardvpn_cli/bash-completion.sh" ] && \. "/opt/adguardvpn_cli/bash-completion.sh"
+```
+
 To use the feature, just start typing the command you want and hit the Tab ↹ key — the command will automatically complete with a necessary word or will show a choice of completion options.
 
 ![bash-completion locations command](https://cdn.adguard-vpn.com/blog/new/1g4nhVPN-CLI-autocomplete.png)


### PR DESCRIPTION
I didn't think to enable autocompletions when I installed the VPN initially, and upon looking up how to do so the required line of code only exists in a screenshot which can't be copied and pasted into my `.bashrc` file.

This PR adds the appropriate code, using the default output directory path, as a code block so that users can copy it and paste it into their config file more easily.